### PR TITLE
Improve YouTube transcript retrieval handling

### DIFF
--- a/module/summarize_video.py
+++ b/module/summarize_video.py
@@ -2,7 +2,12 @@ import os
 import argparse
 import re
 import google.generativeai as genai
-from youtube_transcript_api import YouTubeTranscriptApi
+from youtube_transcript_api import (
+    YouTubeTranscriptApi,
+    NoTranscriptFound,
+    TranscriptsDisabled,
+    VideoUnavailable,
+)
 from pytube import YouTube
 
 # --- 設定區 ---
@@ -23,23 +28,148 @@ def get_video_id(url):
             return match.group(1)
     return None
 
-def get_youtube_content(video_id):
-    """根據 video_id 取得影片標題和逐字稿"""
+def get_youtube_content(video_id, target_language="zh-Hant"):
+    """根據 video_id 取得影片標題和逐字稿。
+
+    Args:
+        video_id: YouTube 影片 ID。
+        target_language: 希望取得或翻譯的字幕語系，預設為繁體中文。
+
+    Returns:
+        tuple[str | None, str | None, str | None]:
+            - title: 影片標題（若取得失敗則為 None）。
+            - transcript: 取得成功的字幕內容，失敗時為 None。
+            - error_message: 取得字幕失敗時給使用者的說明訊息，成功時為 None。
+    """
+
     try:
-        # 使用 Pytube 獲取影片標題
         yt = YouTube(f"https://www.youtube.com/watch?v={video_id}")
         title = yt.title
-        
-        # 使用 youtube-transcript-api 獲取逐字稿
-        transcript_list = YouTubeTranscriptApi.get_transcript(video_id, languages=['zh-TW', 'zh-Hant', 'en', 'zh-Hans'])
-        transcript = " ".join([item['text'] for item in transcript_list])
-        
-        return title, transcript
-    except Exception as e:
-        print(f"錯誤：無法獲取影片 '{video_id}' 的內容。")
-        print(f"詳細原因: {e}")
-        # 這裡可以加入 Whisper 作為備用方案，但為了簡化此獨立工具，暫不加入
-        return None, None
+    except Exception as exc:  # pragma: no cover - 極少觸發，仍提供說明
+        return None, None, f"無法載入影片資訊：{exc}"
+
+    transcript_api = YouTubeTranscriptApi()
+    language_preferences = [target_language, "zh-TW", "zh-Hant", "en", "zh-Hans"]
+
+    try:
+        transcript_list = _fetch_transcript(transcript_api, video_id, language_preferences)
+        transcript = " ".join(item["text"] for item in transcript_list)
+        return title, transcript, None
+    except NoTranscriptFound:
+        return _handle_missing_transcript(transcript_api, video_id, title, target_language)
+    except TranscriptsDisabled:
+        message = "這支影片的字幕已被停用，無法取得逐字稿。"
+        return title, None, message
+    except VideoUnavailable:
+        message = "影片不存在或已移除，無法取得逐字稿。"
+        return None, None, message
+    except Exception as exc:  # pragma: no cover - 捕捉其他罕見錯誤
+        message = f"取得字幕時發生未知錯誤：{exc}"
+        return title, None, message
+
+
+def _handle_missing_transcript(transcript_api, video_id, title, target_language):
+    """當指定語言字幕不存在時嘗試翻譯其他字幕。"""
+
+    try:
+        transcripts_obj = _list_available_transcripts(transcript_api, video_id)
+    except TranscriptsDisabled:
+        message = "這支影片的字幕已被停用，無法取得逐字稿。"
+        return title, None, message
+    except VideoUnavailable:
+        message = "影片不存在或已移除，無法取得逐字稿。"
+        return None, None, message
+    except Exception as exc:  # pragma: no cover - 捕捉其他罕見錯誤
+        message = f"無法取得字幕清單：{exc}"
+        return title, None, message
+
+    transcript_list = None
+
+    try:
+        transcript_obj = transcripts_obj.find_transcript([target_language])
+        transcript_list = _to_raw_transcript(transcript_obj.fetch())
+    except NoTranscriptFound:
+        transcript_list = None
+
+    if transcript_list is None:
+        available_transcripts = list(transcripts_obj)
+        for transcript in available_transcripts:
+            if not getattr(transcript, "is_translatable", False):
+                continue
+            try:
+                translated = transcript.translate(target_language)
+                transcript_list = _to_raw_transcript(translated.fetch())
+                break
+            except (NoTranscriptFound, TranscriptsDisabled, VideoUnavailable):
+                continue
+            except Exception:  # pragma: no cover - 忽略其他翻譯錯誤
+                continue
+    else:
+        available_transcripts = list(transcripts_obj)
+
+    if transcript_list:
+        transcript = " ".join(item["text"] for item in transcript_list)
+        return title, transcript, None
+
+    available_languages = sorted(
+        {getattr(t, "language_code", "") for t in available_transcripts if getattr(t, "language_code", "")}
+    )
+
+    if available_languages:
+        message = (
+            "影片僅提供以下語言的字幕，且無法翻譯成"
+            f"{_format_target_language(target_language)}： {', '.join(available_languages)}。"
+        )
+    else:
+        message = (
+            "這支影片沒有可用的字幕，也無法翻譯成"
+            f"{_format_target_language(target_language)}。"
+        )
+
+    return title, None, message
+
+
+def _fetch_transcript(transcript_api, video_id, languages):
+    """取得指定語言優先序的字幕內容。"""
+
+    if hasattr(transcript_api, "get_transcript"):
+        return transcript_api.get_transcript(video_id, languages=languages)
+
+    if hasattr(YouTubeTranscriptApi, "get_transcript"):
+        return YouTubeTranscriptApi.get_transcript(video_id, languages=languages)
+
+    fetched = transcript_api.fetch(video_id, languages=languages)
+    return _to_raw_transcript(fetched)
+
+
+def _list_available_transcripts(transcript_api, video_id):
+    """取得可用字幕的 TranscriptList 物件。"""
+
+    if hasattr(transcript_api, "list_transcripts"):
+        return transcript_api.list_transcripts(video_id)
+
+    if hasattr(YouTubeTranscriptApi, "list_transcripts"):
+        return YouTubeTranscriptApi.list_transcripts(video_id)
+
+    return transcript_api.list(video_id)
+
+
+def _to_raw_transcript(fetched_transcript):
+    """將 FetchedTranscript 轉換成原始資料格式。"""
+
+    if hasattr(fetched_transcript, "to_raw_data"):
+        return fetched_transcript.to_raw_data()
+
+    return list(fetched_transcript)
+
+
+def _format_target_language(target_language):
+    """回傳顯示用的目標字幕語言描述。"""
+
+    if target_language == "zh-Hant":
+        return "繁體中文"
+
+    return f"指定的語言 ({target_language})"
 
 def get_summary_from_gemini(content, api_key):
     """將內容傳送給 Gemini API 以獲取摘要"""
@@ -86,11 +216,11 @@ def main():
 
     print(f"正在處理影片 ID: {video_id}")
     
-    title, transcript = get_youtube_content(video_id)
+    title, transcript, error_message = get_youtube_content(video_id)
 
     if transcript:
         summary = get_summary_from_gemini(transcript, GEMINI_API_KEY)
-        
+
         print("\n==================================================")
         print(f"影片標題： {title}")
         print("==================================================")
@@ -100,6 +230,8 @@ def main():
         # print("\n--- 完整逐字稿 ---\n") # 如果需要，可以取消這一行的註解來顯示完整逐字稿
         # print(transcript)
         print("==================================================")
+    elif error_message:
+        print(error_message)
 
 if __name__ == "__main__":
     main()

--- a/tests/test_summarize_video.py
+++ b/tests/test_summarize_video.py
@@ -1,0 +1,112 @@
+from pathlib import Path
+import sys
+
+from youtube_transcript_api import NoTranscriptFound, TranscriptsDisabled, VideoUnavailable
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import module.summarize_video as summarize_video
+
+
+class DummyYouTube:
+    def __init__(self, *_args, **_kwargs):
+        self.title = "Dummy Title"
+
+
+def setup_youtube_mock(monkeypatch):
+    monkeypatch.setattr(summarize_video, "YouTube", DummyYouTube)
+
+
+def setup_transcript_api_mock(monkeypatch, *, fetch_impl, list_impl=None):
+    class FakeYouTubeTranscriptApi:
+        def __init__(self, *_args, **_kwargs):
+            self._fetch_impl = fetch_impl
+            self._list_impl = list_impl
+
+        def fetch(self, video_id, languages):
+            if self._fetch_impl is None:
+                raise AssertionError("fetch should not be called")
+            return self._fetch_impl(video_id, languages)
+
+        def list(self, video_id):
+            if self._list_impl is None:
+                raise AssertionError("list should not be called")
+            return self._list_impl(video_id)
+
+    monkeypatch.setattr(summarize_video, "YouTubeTranscriptApi", FakeYouTubeTranscriptApi)
+
+
+def test_get_youtube_content_transcripts_disabled_returns_message(monkeypatch):
+    setup_youtube_mock(monkeypatch)
+
+    def fetch_impl(_video_id, _languages):
+        raise TranscriptsDisabled("disabled")
+
+    setup_transcript_api_mock(monkeypatch, fetch_impl=fetch_impl)
+
+    title, transcript, message = summarize_video.get_youtube_content("video123")
+
+    assert title == "Dummy Title"
+    assert transcript is None
+    assert message == "這支影片的字幕已被停用，無法取得逐字稿。"
+
+
+def test_get_youtube_content_video_unavailable_returns_message(monkeypatch):
+    setup_youtube_mock(monkeypatch)
+
+    def fetch_impl(_video_id, _languages):
+        raise VideoUnavailable("gone")
+
+    setup_transcript_api_mock(monkeypatch, fetch_impl=fetch_impl)
+
+    title, transcript, message = summarize_video.get_youtube_content("video456")
+
+    assert title is None
+    assert transcript is None
+    assert message == "影片不存在或已移除，無法取得逐字稿。"
+
+
+def test_get_youtube_content_no_transcript_returns_available_language_message(monkeypatch):
+    setup_youtube_mock(monkeypatch)
+
+    def fetch_impl(video_id, _languages):
+        raise NoTranscriptFound(video_id, ["zh-Hant"], [])
+
+    class FakeTranscript:
+        def __init__(self, language_code, is_translatable):
+            self.language_code = language_code
+            self.language = language_code
+            self.is_translatable = is_translatable
+
+        def translate(self, _target_language):
+            raise NoTranscriptFound("video789", ["zh-Hant"], [])
+
+    class FakeTranscriptList:
+        def __init__(self, transcripts):
+            self._transcripts = transcripts
+
+        def find_transcript(self, _languages):
+            raise NoTranscriptFound("video789", ["zh-Hant"], [])
+
+        def __iter__(self):
+            return iter(self._transcripts)
+
+    transcripts = [
+        FakeTranscript("en", is_translatable=True),
+        FakeTranscript("ja", is_translatable=False),
+    ]
+
+    setup_transcript_api_mock(
+        monkeypatch,
+        fetch_impl=fetch_impl,
+        list_impl=lambda _video_id: FakeTranscriptList(transcripts),
+    )
+
+    title, transcript, message = summarize_video.get_youtube_content("video789")
+
+    assert title == "Dummy Title"
+    assert transcript is None
+    assert (
+        message
+        == "影片僅提供以下語言的字幕，且無法翻譯成繁體中文： en, ja。"
+    )


### PR DESCRIPTION
## Summary
- handle youtube_transcript_api errors explicitly, provide friendly messages, and try translating available transcripts when the preferred language is missing
- add compatibility helpers so transcript fetching works across different youtube_transcript_api interfaces
- add pytest coverage for transcript error scenarios using mocked API stubs

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68c84e58fcec8329a343df7d8373f7d8