### PR TITLE
Add Whisper fallback when YouTube transcripts unavailable

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,7 @@ python -m venv .venv
 pip install -r requirements.txt
 python main.py
 ```
+- Offline transcript fallback requires additional tools: `yt-dlp`, `openai-whisper`, and the system-level `ffmpeg` binary. Install ffmpeg via your OS package manager (e.g., `apt`, `brew`, `choco`).
 
 
 ## Coding Style & Naming

--- a/module/summarize_video.py
+++ b/module/summarize_video.py
@@ -1,7 +1,6 @@
 import os
 import argparse
 import re
-import importlib
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Optional, Tuple
@@ -14,6 +13,8 @@ from youtube_transcript_api import (
     VideoUnavailable,
 )
 from pytube import YouTube
+from yt_dlp import YoutubeDL
+from yt_dlp.utils import DownloadError
 
 # --- 設定區 ---
 # 從環境變數讀取 API 金鑰
@@ -25,6 +26,13 @@ _WHISPER_IMPORT_FAILED = False
 
 def get_youtube_content(video_id: str):
     try:
+        title = YouTube(f"https://www.youtube.com/watch?v={video_id}").title
+    except VideoUnavailable as e:
+        return None, None, f"錯誤：無法存取影片 '{video_id}'。詳細原因: {e}"
+    except Exception as e:
+        return None, None, f"錯誤：無法載入影片 '{video_id}' 的資訊。詳細原因: {e}"
+
+    try:
         transcripts = YouTubeTranscriptApi.list_transcripts(video_id)
         try:
             # Try native Chinese transcript first
@@ -34,11 +42,22 @@ def get_youtube_content(video_id: str):
             transcript = (transcripts.find_transcript(['en', 'ja', 'auto'])
                            .translate('zh-Hant')
                            .fetch())
-        title = YouTube(f"https://www.youtube.com/watch?v={video_id}").title
         text = "\n".join(item["text"] for item in transcript)
         return title, text, None
+    except (NoTranscriptFound, TranscriptsDisabled) as transcript_error:
+        print(
+            f"偵測到官方字幕不可用（{transcript_error}），改用 yt-dlp + Whisper 進行備援轉錄..."
+        )
+        transcript_text, fallback_error = generate_transcript_with_whisper(video_id)
+        if transcript_text:
+            return title, transcript_text, None
+        error_message = (
+            "錯誤：影片沒有可用字幕，且備援語音轉文字流程失敗。"
+            f" 原始錯誤: {transcript_error}; 備援錯誤: {fallback_error}"
+        )
+        return title, None, error_message
     except Exception as e:
-        return None, None, f"錯誤：無法獲取影片 '{video_id}' 的內容。詳細原因: {e}"
+        return title, None, f"錯誤：無法獲取影片 '{video_id}' 的內容。詳細原因: {e}"
 
 def get_video_id(url):
     """從各種 YouTube URL 格式中解析出 video_id"""
@@ -84,6 +103,81 @@ def get_summary_from_gemini(content, api_key):
 
     except Exception as e:
         return f"錯誤：呼叫 Gemini API 失敗。詳細原因: {e}"
+
+
+def load_whisper_model():
+    """Lazy-load Whisper 模型，避免在未安裝時崩潰"""
+    global _WHISPER_MODEL, _WHISPER_IMPORT_FAILED
+
+    if _WHISPER_MODEL is not None:
+        return _WHISPER_MODEL
+
+    if _WHISPER_IMPORT_FAILED:
+        raise RuntimeError("Whisper 模組先前載入失敗，請確認已安裝 openai-whisper。")
+
+    try:
+        import whisper  # type: ignore
+    except ImportError as exc:  # pragma: no cover - 依賴於外部環境
+        _WHISPER_IMPORT_FAILED = True
+        raise RuntimeError(
+            "Whisper 模組未安裝。請執行 `pip install openai-whisper`。"
+        ) from exc
+
+    try:
+        _WHISPER_MODEL = whisper.load_model(WHISPER_MODEL_NAME)
+    except Exception as exc:  # pragma: no cover - 實際錯誤依環境而定
+        _WHISPER_IMPORT_FAILED = True
+        raise RuntimeError(f"Whisper 模型載入失敗：{exc}") from exc
+
+    return _WHISPER_MODEL
+
+
+def download_audio_with_ytdlp(video_id: str, output_dir: Path) -> Path:
+    """使用 yt-dlp 下載指定影片的最佳音訊"""
+    video_url = f"https://www.youtube.com/watch?v={video_id}"
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    options = {
+        "format": "bestaudio/best",
+        "outtmpl": str(output_dir / "%(id)s.%(ext)s"),
+        "noplaylist": True,
+        "quiet": True,
+        "no_warnings": True,
+    }
+
+    try:
+        with YoutubeDL(options) as ydl:
+            ydl.download([video_url])
+    except DownloadError as exc:
+        raise RuntimeError(f"yt-dlp 下載音訊失敗：{exc}") from exc
+
+    downloaded_files = list(output_dir.glob(f"{video_id}.*"))
+    if not downloaded_files:
+        raise RuntimeError("yt-dlp 下載完成，但找不到音訊檔案。")
+
+    return downloaded_files[0]
+
+
+def transcribe_audio_with_whisper(audio_path: Path) -> str:
+    """使用 Whisper 對音訊檔進行轉錄"""
+    model = load_whisper_model()
+    result = model.transcribe(str(audio_path))
+    text = result.get("text", "").strip()
+    if not text:
+        raise RuntimeError("Whisper 未能產生有效的逐字稿。")
+    return text
+
+
+def generate_transcript_with_whisper(video_id: str) -> Tuple[Optional[str], Optional[str]]:
+    """利用 yt-dlp + Whisper 取得影片的備援逐字稿"""
+    try:
+        with TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            audio_file = download_audio_with_ytdlp(video_id, tmp_path)
+            transcript_text = transcribe_audio_with_whisper(audio_file)
+            return transcript_text, None
+    except Exception as exc:
+        return None, str(exc)
 
 def main():
     """程式主進入點"""

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,6 @@ beautifulsoup4
 pytube==15.0.0
 google-generativeai
 yt-dlp
-# 離線語音轉文字備援所需套件（可選，但若要啟用 fallback 請務必安裝）
-# pip install --upgrade openai-whisper
-# 需要系統層級安裝 ffmpeg，可搭配 Python 介面：
-# pip install ffmpeg-python
+openai-whisper
+ffmpeg-python
+# 系統層級依賴：ffmpeg（請使用套件管理器安裝，如 apt、brew 等）


### PR DESCRIPTION
## Summary
- add a yt-dlp + Whisper fallback when YouTube transcripts are disabled or missing
- implement helper utilities to download audio, load Whisper models, and transcribe audio for summarization
- document the new offline transcription dependencies and add them to requirements

## Testing
- python -m compileall module/summarize_video.py

------
https://chatgpt.com/codex/tasks/task_e_68c91136afd88329a258fb43134fa822