### PR TITLE
Handle Whisper fallback errors

### DIFF
--- a/module/summarize_video.py
+++ b/module/summarize_video.py
@@ -1,12 +1,19 @@
 import os
 import argparse
 import re
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import Optional, Tuple
 
 import google.generativeai as genai
 from youtube_transcript_api import YouTubeTranscriptApi
 from pytube import YouTube
 from yt_dlp import YoutubeDL
 from yt_dlp.utils import DownloadError
+
+_WHISPER_MODEL = None
+_WHISPER_IMPORT_FAILED = False
+WHISPER_MODEL_NAME = "base"
 
 # 匯入 Whisper 函式庫，並處理可能未安裝的情況
 try:
@@ -74,7 +81,7 @@ def get_youtube_content(video_id):
             
             # 2. 使用 Whisper 轉錄
             print("正在使用 Whisper 進行語音轉文字，這可能需要一些時間...")
-            model = whisper.load_model("base") # "base" 模型速度快，效果不錯
+            model = whisper.load_model(WHISPER_MODEL_NAME)  # 使用預設 Whisper 模型
             result = model.transcribe(audio_file)
             transcript = result['text']
             
@@ -139,7 +146,9 @@ def load_whisper_model():
     return _WHISPER_MODEL
 
 
-def download_audio_with_ytdlp(video_id: str, output_dir: Path) -> Path:
+def download_audio_with_ytdlp(
+    video_id: str, output_dir: Path
+) -> Tuple[Optional[Path], Optional[str]]:
     """使用 yt-dlp 下載指定影片的最佳音訊"""
     video_url = f"https://www.youtube.com/watch?v={video_id}"
     output_dir.mkdir(parents=True, exist_ok=True)
@@ -156,13 +165,15 @@ def download_audio_with_ytdlp(video_id: str, output_dir: Path) -> Path:
         with YoutubeDL(options) as ydl:
             ydl.download([video_url])
     except DownloadError as exc:
-        raise RuntimeError(f"yt-dlp 下載音訊失敗：{exc}") from exc
+        return None, f"yt-dlp 下載音訊失敗：{exc}"
+    except Exception as exc:  # pragma: no cover - 依賴於外部工具
+        return None, f"yt-dlp 下載音訊時發生未預期的錯誤：{exc}"
 
     downloaded_files = list(output_dir.glob(f"{video_id}.*"))
     if not downloaded_files:
-        raise RuntimeError("yt-dlp 下載完成，但找不到音訊檔案。")
+        return None, "yt-dlp 下載完成，但找不到音訊檔案。"
 
-    return downloaded_files[0]
+    return downloaded_files[0], None
 
 
 def transcribe_audio_with_whisper(audio_path: Path) -> str:
@@ -180,10 +191,19 @@ def generate_transcript_with_whisper(video_id: str) -> Tuple[Optional[str], Opti
     try:
         with TemporaryDirectory() as tmp_dir:
             tmp_path = Path(tmp_dir)
-            audio_file = download_audio_with_ytdlp(video_id, tmp_path)
-            transcript_text = transcribe_audio_with_whisper(audio_file)
+            audio_file, download_error = download_audio_with_ytdlp(video_id, tmp_path)
+            if download_error:
+                return None, download_error
+            if audio_file is None:  # 型別保險，理論上不會發生
+                return None, "yt-dlp 未傳回音訊檔案。"
+
+            try:
+                transcript_text = transcribe_audio_with_whisper(audio_file)
+            except Exception as exc:  # pragma: no cover - 依環境而定
+                return None, str(exc)
+
             return transcript_text, None
-    except Exception as exc:
+    except Exception as exc:  # pragma: no cover - 建立暫存目錄失敗等
         return None, str(exc)
 
 def main():

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,6 @@ google-generativeai
 yt-dlp
 openai-whisper
 ffmpeg-python
-# 系統層級依賴：ffmpeg（請使用套件管理器安裝，如 apt、brew 等）
+# Whisper/yt-dlp 備援轉錄流程需要：
+# - pip 套件：yt-dlp、openai-whisper、ffmpeg-python
+# - 系統層級 ffmpeg 二進位檔（請以 apt、brew、choco 等套件管理器安裝）


### PR DESCRIPTION
## Summary
- add reusable Whisper configuration constants to `summarize_video.py`
- make yt-dlp and Whisper transcript helpers return error messages instead of raising
- document the Whisper/yt-dlp/ffmpeg fallback dependencies in `requirements.txt`

## Testing
- python -m compileall module/summarize_video.py

------
https://chatgpt.com/codex/tasks/task_e_68c918ea2fc083298ae9824f57131518