### PR TITLE
Pin yt-dlp dependency and document update guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,7 @@ pip install -r requirements.txt
 python main.py
 ```
 - Offline transcript fallback requires additional tools: `yt-dlp`, `openai-whisper`, and the system-level `ffmpeg` binary. Install ffmpeg via your OS package manager (e.g., `apt`, `brew`, `choco`).
+- If transcript retrieval fails, verify that `youtube-transcript-api`, `pytube`, and `yt-dlp` are up to date, and check for newer releases.
 
 
 ## Coding Style & Naming

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ requests
 beautifulsoup4
 pytube==15.0.0
 google-generativeai
-yt-dlp
+yt-dlp==2025.01.12
 openai-whisper
 ffmpeg-python
 # 系統層級依賴：ffmpeg（請使用套件管理器安裝，如 apt、brew 等）


### PR DESCRIPTION
## Summary
- pin yt-dlp to version 2025.01.12 in the Python requirements to ensure stable installations
- document a troubleshooting note in the setup guide recommending dependency update checks when transcript retrieval fails

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c91901d3d88329998bf9dd9647d5b8