### PR TITLE
Handle transcript method fallback instantiation

### DIFF
--- a/module/summarize_video.py
+++ b/module/summarize_video.py
@@ -82,6 +82,9 @@ def _call_transcript_method(owner: object, method_name: str, *args):
         if "positional argument" not in str(exc) or not isinstance(owner, type):
             raise
         try:
+            return method(owner(), *args)
+        except Exception:
+            return None
 
 
 def _list_transcripts_for_video(video_id: str):


### PR DESCRIPTION
## Summary
- instantiate transcript API owners when encountering unbound methods
- return None if retrying the method call raises an exception

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c929813c988329bb9353250fb07235