### PR TITLE
Add coverage for transcript helper instantiation

### DIFF
--- a/module/summarize_video.py
+++ b/module/summarize_video.py
@@ -81,8 +81,19 @@ def _call_transcript_method(owner: object, method_name: str, *args):
     except TypeError as exc:
         if "positional argument" not in str(exc) or not isinstance(owner, type):
             raise
+        instance = owner()
         try:
+            bound_method = getattr(instance, method_name)
+        except AttributeError:
+            return None
 
+        if not callable(bound_method):
+            return None
+
+        try:
+            return bound_method(*args)
+        except AssertionError:
+            return None
 
 def _list_transcripts_for_video(video_id: str):
     """嘗試以各種方式列出影片的字幕清單。"""

--- a/tests/test_call_transcript_method.py
+++ b/tests/test_call_transcript_method.py
@@ -1,0 +1,41 @@
+from pathlib import Path
+import sys
+
+import pytest
+
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import module.summarize_video as summarize_video
+
+
+def test_call_transcript_method_instantiates_owner_for_instance_method():
+    class NeedsInstance:
+        instances = []
+
+        def __init__(self):
+            NeedsInstance.instances.append(self)
+            self.calls = []
+
+        def perform(self, payload):
+            self.calls.append(payload)
+            return f"handled:{payload}"
+
+    NeedsInstance.instances.clear()
+
+    result = summarize_video._call_transcript_method(
+        NeedsInstance, "perform", "data"
+    )
+
+    assert result == "handled:data"
+    assert len(NeedsInstance.instances) == 1
+    assert NeedsInstance.instances[0].calls == ["data"]
+
+
+def test_call_transcript_method_reraises_unrelated_type_error():
+    class RaisesTypeError:
+        def perform(self, payload):
+            raise TypeError("custom failure")
+
+    with pytest.raises(TypeError, match="custom failure"):
+        summarize_video._call_transcript_method(RaisesTypeError, "perform", "data")


### PR DESCRIPTION
## Summary
- ensure `_call_transcript_method` instantiates transcript owners when their methods require `self`
- guard against non-callable attributes during the fallback lookup and preserve assertion handling
- add unit tests covering successful instance invocation and propagation of unrelated `TypeError`s

## Testing
- pytest -q

## Impacted Modules
- module/summarize_video.py
- tests/test_call_transcript_method.py

------
https://chatgpt.com/codex/tasks/task_e_68c92983fa7483298aa7b9fc660a4bb1