### PR TITLE
Fix TypeError fallback in transcript helper

### DIFF
--- a/module/summarize_video.py
+++ b/module/summarize_video.py
@@ -79,7 +79,8 @@ def _call_transcript_method(owner: object, method_name: str, *args):
             raise
         instance = owner()
         try:
-
+            bound_method = getattr(instance, method_name)
+        except AttributeError:
             return None
 
         if not callable(bound_method):


### PR DESCRIPTION
## Summary
- restore the fallback path in `_call_transcript_method` so TypeError retries on an instance
- guard against missing attributes and non-callable results before invoking the method

## Testing
- python summarize_video.py https://www.youtube.com/watch?v=dQw4w9WgXcQ
- pytest tests/test_call_transcript_method.py

------
https://chatgpt.com/codex/tasks/task_e_68c983aeb48c83298f6090244fb178a2